### PR TITLE
Hotfix: Disable un-unused-vars

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   "rules": {
     "no-console": "off",               // Whether block console.log statement.
     "no-loops/no-loops": "error",      // use map / forEach instead of for / while
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-unused-vars": "off"
   }
 }


### PR DESCRIPTION
unused-vars 가 있을때 eslint가 에러를 발생시켜 해당 규칙 끔