### PR TITLE
Bugfix: fix prettier script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "lint-and-fix": "eslint . --ext .ts --fix",
-    "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write"
+    "prettier-format": "prettier --config .prettierrc src/**/*.ts --write"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.eslintrc.json
+++ b/tsconfig.eslintrc.json
@@ -4,7 +4,7 @@
     "types": ["jest"]
   },
   "include": [
-    "src", "tests"
+    "src", "tests", "jest.config.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
스크립트 중 `eslint`, `prettier`가 작동하지 않아서 수정함

- `eslint`에 `jest.config.ts`도 포함하도록변경
- `prettier` 수행 시 경로에 따옴표가 있는것을 제거